### PR TITLE
Update build

### DIFF
--- a/build
+++ b/build
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
-bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg &&
-pip uninstall -y tensorflow &&
+bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
+
+pip uninstall -y tensorflow
 pip install /tmp/tensorflow_pkg/tensorflow-1.3.0-cp27-cp27mu-linux_x86_64.whl


### PR DESCRIPTION
If tensorflow isn't currently already installed via `pip`, the  `build` script doesn't actually install a newly built `whl` file.  This is due to `pip uninstall -y tensorflow` complaining that tensorflow isn't installed, and due to the `&&` , then the following `pip install` command doesn't run.  Unfortunately, `pip` doesn't seem to have a `-f` flag.  

Proposed fix:  unchain the bash commands to always allow the `pip install` to happen, regardless of the result of `pip uninstall`.