### PR TITLE
Update CROSSTOOL_hipcc.tpl to support ROCm 1.8

### DIFF
--- a/third_party/gpus/crosstool/CROSSTOOL_hipcc.tpl
+++ b/third_party/gpus/crosstool/CROSSTOOL_hipcc.tpl
@@ -132,6 +132,8 @@ toolchain {
   cxx_builtin_include_directory: "/opt/rocm/hcc/include"
   cxx_builtin_include_directory: "/opt/rocm/hcc/compiler/lib/clang/6.0.0/include/"
   cxx_builtin_include_directory: "/opt/rocm/hcc/lib/clang/6.0.0/include"
+  cxx_builtin_include_directory: "/opt/rocm/hcc/compiler/lib/clang/7.0.0/include/"
+  cxx_builtin_include_directory: "/opt/rocm/hcc/lib/clang/7.0.0/include"
 
   compilation_mode_flags {
     mode: DBG
@@ -239,6 +241,8 @@ toolchain {
   cxx_builtin_include_directory: "/opt/rocm/hcc/include"
   cxx_builtin_include_directory: "/opt/rocm/hcc/compiler/lib/clang/6.0.0/include/"
   cxx_builtin_include_directory: "/opt/rocm/hcc/lib/clang/6.0.0/include"
+  cxx_builtin_include_directory: "/opt/rocm/hcc/compiler/lib/clang/7.0.0/include/"
+  cxx_builtin_include_directory: "/opt/rocm/hcc/lib/clang/7.0.0/include"
 
   compilation_mode_flags {
     mode: DBG


### PR DESCRIPTION
ROCm 1.8 uses hcc/lib/clang/7.0.0 instead of 6.0.0.  This is now supported in the Tensorflow build.