### PR TITLE
Change the default optimization on ROCm to be -march=haswell

### DIFF
--- a/configure
+++ b/configure
@@ -302,7 +302,7 @@ if [ -z "$CC_OPT_FLAGS" ]; then
     # gcc on ppc64le does not support -march, use mcpu instead
     default_cc_opt_flags="-mcpu=native"
   else
-    default_cc_opt_flags="-march=native"
+    default_cc_opt_flags="-march=haswell"
   fi
   read -p "Please specify optimization flags to use during compilation when bazel option "\
 "\"--config=opt\" is specified [Default is $default_cc_opt_flags]: " CC_OPT_FLAGS

--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -30,7 +30,7 @@ option(tensorflow_BUILD_CONTRIB_KERNELS "Build OpKernels from tensorflow/contrib
 option(tensorflow_BUILD_CC_TESTS "Build cc unit tests " OFF)
 option(tensorflow_BUILD_PYTHON_TESTS "Build python unit tests " OFF)
 option(tensorflow_BUILD_SHARED_LIB "Build TensorFlow as a shared library" OFF)
-option(tensorflow_OPTIMIZE_FOR_NATIVE_ARCH "Enable compiler optimizations for the native processor architecture (if available)" ON)
+option(tensorflow_OPTIMIZE_FOR_NATIVE_ARCH "Enable compiler optimizations for the native processor architecture (if available)" OFF)
 option(tensorflow_WIN_CPU_SIMD_OPTIONS "Enables CPU SIMD instructions")
 
 if (NOT WIN32)
@@ -86,7 +86,7 @@ endif()
 
 if (tensorflow_OPTIMIZE_FOR_NATIVE_ARCH)
   include(CheckCXXCompilerFlag)
-  CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
+  CHECK_CXX_COMPILER_FLAG("-march=" COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
   if (COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
   endif()

--- a/tensorflow/contrib/makefile/build_all_linux.sh
+++ b/tensorflow/contrib/makefile/build_all_linux.sh
@@ -37,5 +37,5 @@ tensorflow/contrib/makefile/compile_linux_protobuf.sh
 
 # Build TensorFlow.
 make -j"${JOB_COUNT}" -f tensorflow/contrib/makefile/Makefile \
-  OPTFLAGS="-O3 -march=native" \
-  HOST_CXXFLAGS="--std=c++11 -march=native"
+  OPTFLAGS="-O3 -march=haswell" \
+  HOST_CXXFLAGS="--std=c++11 -march=haswell"

--- a/tensorflow/docs_src/install/install_sources.md
+++ b/tensorflow/docs_src/install/install_sources.md
@@ -228,7 +228,7 @@ the desired version instead of relying on the default.
 One of the questions that `configure` will ask is as follows:
 
 <pre>
-Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=native]
+Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=haswell]
 </pre>
 
 This question refers to a later phase in which you'll use bazel to 
@@ -255,7 +255,7 @@ Please input the desired Python library path to use.  Default is [/usr/lib/pytho
 Using python library path: /usr/local/lib/python2.7/dist-packages
 Do you wish to build TensorFlow with MKL support? [y/N]
 No MKL support will be enabled for TensorFlow
-Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=native]:
+Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=haswell]:
 Do you wish to use jemalloc as the malloc implementation? [Y/n]
 jemalloc enabled
 Do you wish to build TensorFlow with Google Cloud Platform support? [y/N]


### PR DESCRIPTION
This PR set the default opt option to be -march="haswell" on ROCm.
With this PR, the TF package can work fine on both AMD EPYC systems and Intel post-Haswell systems.