### PR TITLE
Tmp disable feature_column_test in run_py3_core.sh

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -45,6 +45,7 @@ bazel test --config=rocm --test_tag_filters=-no_oss,-no_gpu,-benchmark-test -k \
     -//tensorflow/python/estimator:dnn_test \
     -//tensorflow/python/estimator:estimator_test \
     -//tensorflow/python/estimator:linear_test \
+    -//tensorflow/python/feature_column:feature_column_test \
     -//tensorflow/python/kernel_tests:atrous_conv2d_test \
     -//tensorflow/python/kernel_tests:batch_matmul_op_test \
     -//tensorflow/python/kernel_tests:cholesky_op_test \


### PR DESCRIPTION
Feature_column_test appears to occasionally fail.  We'll add it to the temporarily disabled unit test list it to get CI working.